### PR TITLE
[feat] #3 Spring Security oauth2 기본 설정 추가

### DIFF
--- a/src/main/java/com/numble/team3/account/domain/Account.java
+++ b/src/main/java/com/numble/team3/account/domain/Account.java
@@ -1,0 +1,49 @@
+package com.numble.team3.account.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "tb_account")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Account {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "account_id")
+  private Long id;
+
+  @Column(unique = true)
+  private String email;
+
+  @Column(unique = true)
+  private String nickname;
+
+  @Column
+  private String password;
+
+  @Column
+  private String profile;
+
+  @Enumerated(EnumType.STRING)
+  private RoleType roleType = RoleType.ROLE_USER;
+
+  @Column(columnDefinition="tinyint(1)")
+  private boolean deleted = false;
+
+  public Account(String email, String nickname, String profile) {
+    this.email = email;
+    this.nickname = nickname;
+    this.profile = profile;
+  }
+}

--- a/src/main/java/com/numble/team3/account/domain/RoleType.java
+++ b/src/main/java/com/numble/team3/account/domain/RoleType.java
@@ -1,0 +1,5 @@
+package com.numble.team3.account.domain;
+
+public enum RoleType {
+  ROLE_USER, ROLE_ADMIN
+}

--- a/src/main/java/com/numble/team3/account/infra/JpaAccountRepository.java
+++ b/src/main/java/com/numble/team3/account/infra/JpaAccountRepository.java
@@ -1,0 +1,10 @@
+package com.numble.team3.account.infra;
+
+import com.numble.team3.account.domain.Account;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaAccountRepository extends JpaRepository<Account, Long> {
+
+  Optional<Account> findByEmail(String email);
+}

--- a/src/main/java/com/numble/team3/config/RedisConfig.java
+++ b/src/main/java/com/numble/team3/config/RedisConfig.java
@@ -1,0 +1,31 @@
+package com.numble.team3.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+
+  private final RedisProperties redisProperties;
+
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+  }
+
+  @Bean
+  public RedisTemplate<String, Object> redisTemplate() {
+    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setConnectionFactory(redisConnectionFactory());
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setValueSerializer(new StringRedisSerializer());
+    return redisTemplate;
+  }
+}

--- a/src/main/java/com/numble/team3/config/SecurityConfig.java
+++ b/src/main/java/com/numble/team3/config/SecurityConfig.java
@@ -1,9 +1,13 @@
 package com.numble.team3.config;
 
+import com.numble.team3.jwt.TokenHelper;
 import com.numble.team3.security.CustomAccessDeniedHandler;
 import com.numble.team3.security.CustomAuthenticationEntryPoint;
+import com.numble.team3.security.CustomOAuth2UserService;
 import com.numble.team3.security.CustomUserDetailsService;
 import com.numble.team3.security.JwtAuthenticationFilter;
+import com.numble.team3.security.OAuth2SuccessHandler;
+import com.numble.team3.sign.infra.RedisUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -16,6 +20,10 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
   private final CustomUserDetailsService userDetailsService;
+  private final RedisUtils redisUtils;
+  private final TokenHelper accessTokenHelper;
+  private final CustomOAuth2UserService oAuth2UserService;
+  private final OAuth2SuccessHandler oAuth2SuccessHandler;
 
   @Override
   protected void configure(HttpSecurity http) throws Exception {
@@ -37,7 +45,12 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
       .exceptionHandling().authenticationEntryPoint(new CustomAuthenticationEntryPoint())
       .and()
       .addFilterBefore(
-        new JwtAuthenticationFilter(userDetailsService),
-        UsernamePasswordAuthenticationFilter.class);
+        new JwtAuthenticationFilter(userDetailsService, redisUtils, accessTokenHelper),
+        UsernamePasswordAuthenticationFilter.class)
+
+      .oauth2Login()
+      .userInfoEndpoint().userService(oAuth2UserService)
+      .and()
+      .successHandler(oAuth2SuccessHandler).permitAll();
   }
 }

--- a/src/main/java/com/numble/team3/security/CustomOAuth2UserService.java
+++ b/src/main/java/com/numble/team3/security/CustomOAuth2UserService.java
@@ -1,0 +1,35 @@
+package com.numble.team3.security;
+
+import com.numble.team3.account.domain.RoleType;
+import java.util.Collections;
+import java.util.Map;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+  @Override
+  public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+    DefaultOAuth2UserService oAuth2UserService = new DefaultOAuth2UserService();
+    OAuth2User oAuth2User = oAuth2UserService.loadUser(userRequest);
+
+    String registrationId = userRequest.getClientRegistration().getRegistrationId();
+    String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails()
+      .getUserInfoEndpoint().getUserNameAttributeName();
+
+    OAuth2Attribute oAuth2Attribute = OAuth2Attribute.of(registrationId, userNameAttributeName,
+      oAuth2User.getAttributes());
+    Map<String, Object> memberAttribute = oAuth2Attribute.convertToMap();
+
+    return new DefaultOAuth2User(
+      Collections.singleton(new SimpleGrantedAuthority(RoleType.ROLE_USER.toString())),
+      memberAttribute, "email");
+  }
+}

--- a/src/main/java/com/numble/team3/security/OAuth2Attribute.java
+++ b/src/main/java/com/numble/team3/security/OAuth2Attribute.java
@@ -1,0 +1,67 @@
+package com.numble.team3.security;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class OAuth2Attribute {
+
+  private Map<String, Object> attributes;
+  private String attributeKey;
+  private String email;
+  private String nickname;
+  private String profile;
+
+  static OAuth2Attribute of(String provider, String attributeKey, Map<String, Object> attributes) {
+    switch (provider) {
+      case "naver":
+        return ofNaver("id", attributes);
+      case "kakao":
+        return ofKakao("email", attributes);
+      case "google":
+        return ofGoogle(attributeKey, attributes);
+      default:
+        throw new RuntimeException();
+    }
+  }
+
+  private static OAuth2Attribute ofNaver(String attributeKey, Map<String, Object> attributes) {
+    Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+
+    return OAuth2Attribute.builder().nickname((String) response.get("nickname"))
+      .email((String) response.get("email")).profile((String) response.get("profile_image"))
+      .attributes(response).attributeKey(attributeKey).build();
+  }
+
+  private static OAuth2Attribute ofKakao(String attributeKey, Map<String, Object> attributes) {
+    Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+    Map<String, Object> kakaoProfile = (Map<String, Object>) kakaoAccount.get("profile");
+
+    return OAuth2Attribute.builder().nickname((String) kakaoProfile.get("nickname"))
+      .email(String.valueOf(attributes.get("id")))
+      .profile((String) kakaoProfile.get("thumbnail_image_url")).attributes(kakaoAccount)
+      .attributeKey(attributeKey).build();
+  }
+
+  private static OAuth2Attribute ofGoogle(String attributeKey, Map<String, Object> attributes) {
+    return OAuth2Attribute.builder().nickname((String) attributes.get("name"))
+      .email((String) attributes.get("email")).profile((String) attributes.get("picture"))
+      .attributes(attributes).attributeKey(attributeKey).build();
+  }
+
+  Map<String, Object> convertToMap() {
+    Map<String, Object> map = new HashMap<>();
+    map.put("id", attributeKey);
+    map.put("key", attributeKey);
+    map.put("nickname", nickname);
+    map.put("email", email);
+    map.put("profile", profile);
+
+    return map;
+  }
+}
+

--- a/src/main/java/com/numble/team3/security/OAuth2SuccessHandler.java
+++ b/src/main/java/com/numble/team3/security/OAuth2SuccessHandler.java
@@ -1,0 +1,84 @@
+package com.numble.team3.security;
+
+import com.numble.team3.account.domain.Account;
+import com.numble.team3.account.infra.JpaAccountRepository;
+import com.numble.team3.jwt.PrivateClaims;
+import com.numble.team3.jwt.TokenHelper;
+import com.numble.team3.sign.application.response.TokenDto;
+import com.numble.team3.sign.infra.RedisUtils;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Component
+@Transactional
+public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
+
+  private final JpaAccountRepository accountRepository;
+  private final TokenHelper accessTokenHelper;
+  private final TokenHelper refreshTokenHelper;
+  private final RedisUtils redisUtils;
+
+  @Override
+  public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+    Authentication authentication) {
+    OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+
+    accountRepository.findByEmail((String) oAuth2User.getAttributes().get("email"))
+      .ifPresentOrElse(account -> accountProcess(account, response),
+        () -> accountProcess(accountRepository.save(convertAccount(oAuth2User)), response));
+  }
+
+  private Account convertAccount(OAuth2User oAuth2User) {
+    Map<String, Object> attributes = oAuth2User.getAttributes();
+
+    return new Account((String) attributes.get("email"), (String) attributes.get("nickname"),
+      (String) attributes.get("profile"));
+  }
+
+  private void accountProcess(Account account, HttpServletResponse response) {
+    PrivateClaims privateClaims = createPrivateClaims(account);
+    String accessToken = accessTokenHelper.createToken(privateClaims);
+    String refreshToken = refreshTokenHelper.createToken(privateClaims);
+
+    redisUtils.saveAccessToken(account.getId(), accessToken);
+    redisUtils.saveRefreshToken(account.getId(), refreshToken);
+
+    createTokenCookie(response, new TokenDto(accessToken, refreshToken));
+  }
+
+  private void createTokenCookie(HttpServletResponse response, TokenDto token) {
+    Cookie accessTokenCookie = new Cookie("accessToken",
+      URLEncoder.encode(token.getAccessToken(), StandardCharsets.UTF_8));
+    accessTokenCookie.setSecure(true);
+    accessTokenCookie.setHttpOnly(true);
+    accessTokenCookie.setMaxAge(1800);
+    accessTokenCookie.setPath("/");
+
+    Cookie refreshTokenCookie = new Cookie("refreshToken",
+      URLEncoder.encode(token.getRefreshToken(), StandardCharsets.UTF_8));
+    refreshTokenCookie.setSecure(true);
+    refreshTokenCookie.setHttpOnly(true);
+    refreshTokenCookie.setMaxAge(604800);
+    refreshTokenCookie.setPath("/");
+
+    response.addCookie(accessTokenCookie);
+    response.addCookie(refreshTokenCookie);
+  }
+
+  private PrivateClaims createPrivateClaims(Account account) {
+    return new PrivateClaims(String.valueOf(account.getId()),
+      List.of(account.getRoleType().toString()));
+  }
+}

--- a/src/main/java/com/numble/team3/sign/application/response/TokenDto.java
+++ b/src/main/java/com/numble/team3/sign/application/response/TokenDto.java
@@ -1,0 +1,12 @@
+package com.numble.team3.sign.application.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class TokenDto {
+
+  private String accessToken;
+  private String refreshToken;
+}

--- a/src/main/java/com/numble/team3/sign/infra/RedisUtils.java
+++ b/src/main/java/com/numble/team3/sign/infra/RedisUtils.java
@@ -1,0 +1,47 @@
+package com.numble.team3.sign.infra;
+
+import com.numble.team3.jwt.TokenHelper;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisUtils {
+
+  private final RedisTemplate redisTemplate;
+  private final TokenHelper accessTokenHelper;
+  private final TokenHelper refreshTokenHelper;
+
+  private static final String SEPARATOR = "::";
+
+  public void saveAccessToken(Long id, String accessToken) {
+    redisTemplate.opsForValue()
+      .set("accessToken" + SEPARATOR + id, accessToken,
+        accessTokenHelper.getExpiration(accessToken),
+        TimeUnit.SECONDS);
+  }
+
+  public void saveRefreshToken(Long id, String refreshToken) {
+    redisTemplate.opsForValue()
+      .set("refreshToken" + SEPARATOR + id, refreshToken,
+        refreshTokenHelper.getExpiration(refreshToken),
+        TimeUnit.SECONDS);
+  }
+
+  public boolean validToken(String token, String key, Optional<String> id) {
+    return token.equals(
+      getToken(key, id.map(accountId -> Long.valueOf(accountId)).orElse(
+        null)));
+  }
+
+  public String getToken(String key, Long id) {
+    return (String) redisTemplate.opsForValue().get(key + SEPARATOR + id);
+  }
+
+  public void deleteToken(String key, Long id) {
+    redisTemplate.delete(key + SEPARATOR + id);
+  }
+}

--- a/src/main/resources/application-oauth2.yml
+++ b/src/main/resources/application-oauth2.yml
@@ -1,0 +1,41 @@
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: client-id
+            client-secret: client-secret
+            redirect-uri: http:/url/login/oauth2/code/kakao
+            authorization-grant-type: authorization_code
+            client-authentication-method: POST
+            client-name: Kakao
+            scope:
+              - profile_nickname
+              - profile_image
+          naver:
+            client-id: client-id
+            client-secret: client-secret
+            redirect-uri: http://url/login/oauth2/code/naver
+            authorization-grant-type: authorization_code
+            scope:
+              - name
+              - email
+              - profile
+          google:
+            client-id: client-id
+            client-secret: client-secret
+            scope:
+              - email
+              - profile
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,3 +5,7 @@ spring:
       prod2: prod-db
     include:
       - token-secret
+      - oauth2
+  redis:
+    host: 127.0.0.1
+    port: 6379


### PR DESCRIPTION
## 개요
- #3 

## 작업사항
- Spring Security oauth2 기본 설정 완료했습니다.
    - 패키지 `security`에 추가적으로 코드를 작성했습니다.
    - `OAuth2SuccessHandler`에서 회원가입 처리를 하기 위해 `Account` 엔티티 및 리포지토리를 생성했습니다.
    - 토큰 관리를 위해 `RedisUtils`와 `RedisConfig`를 추가했습니다. 
    - oauth2 관련 설정은 application-oauth2.yml 에 있습니다.
        - 현재 파일은 배포 시 테스트 통과를 위한 더미 파일입니다.