### PR TITLE
[feat] Numble3#13 회원가입 & 로그인 & 로그아웃 기능 추가

### DIFF
--- a/src/main/java/com/numble/team3/account/domain/Account.java
+++ b/src/main/java/com/numble/team3/account/domain/Account.java
@@ -9,13 +9,19 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
+@Setter
+@Builder
 @Table(name = "tb_account")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Account {
 
   @Id
@@ -36,10 +42,11 @@ public class Account {
   private String profile;
 
   @Enumerated(EnumType.STRING)
+  @Builder.Default
   private RoleType roleType = RoleType.ROLE_USER;
 
   @Column(columnDefinition="tinyint(1)")
-  private boolean deleted = false;
+  private boolean deleted;
 
   public Account(String email, String nickname, String profile) {
     this.email = email;

--- a/src/main/java/com/numble/team3/account/infra/JpaAccountRepository.java
+++ b/src/main/java/com/numble/team3/account/infra/JpaAccountRepository.java
@@ -7,4 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface JpaAccountRepository extends JpaRepository<Account, Long> {
 
   Optional<Account> findByEmail(String email);
+
+  boolean existsByEmail(String email);
+
+  boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/numble/team3/exception/account/AccountEmailAlreadyExistsException.java
+++ b/src/main/java/com/numble/team3/exception/account/AccountEmailAlreadyExistsException.java
@@ -1,0 +1,5 @@
+package com.numble.team3.exception.account;
+
+public class AccountEmailAlreadyExistsException extends RuntimeException {
+
+}

--- a/src/main/java/com/numble/team3/exception/account/AccountNicknameAlreadyExistsException.java
+++ b/src/main/java/com/numble/team3/exception/account/AccountNicknameAlreadyExistsException.java
@@ -1,0 +1,5 @@
+package com.numble.team3.exception.account;
+
+public class AccountNicknameAlreadyExistsException extends RuntimeException {
+
+}

--- a/src/main/java/com/numble/team3/exception/account/AccountNotFoundException.java
+++ b/src/main/java/com/numble/team3/exception/account/AccountNotFoundException.java
@@ -1,0 +1,5 @@
+package com.numble.team3.exception.account;
+
+public class AccountNotFoundException extends RuntimeException {
+
+}

--- a/src/main/java/com/numble/team3/exception/sign/SignInFailureException.java
+++ b/src/main/java/com/numble/team3/exception/sign/SignInFailureException.java
@@ -1,0 +1,5 @@
+package com.numble.team3.exception.sign;
+
+public class SignInFailureException extends RuntimeException {
+
+}

--- a/src/main/java/com/numble/team3/exception/sign/TokenFailureException.java
+++ b/src/main/java/com/numble/team3/exception/sign/TokenFailureException.java
@@ -1,0 +1,5 @@
+package com.numble.team3.exception.sign;
+
+public class TokenFailureException extends RuntimeException {
+
+}

--- a/src/main/java/com/numble/team3/sign/application/RedisSignService.java
+++ b/src/main/java/com/numble/team3/sign/application/RedisSignService.java
@@ -1,0 +1,109 @@
+package com.numble.team3.sign.application;
+
+import com.numble.team3.account.domain.Account;
+import com.numble.team3.exception.account.AccountEmailAlreadyExistsException;
+import com.numble.team3.exception.account.AccountNicknameAlreadyExistsException;
+import com.numble.team3.exception.account.AccountNotFoundException;
+import com.numble.team3.account.infra.JpaAccountRepository;
+import com.numble.team3.exception.sign.TokenFailureException;
+import com.numble.team3.jwt.PrivateClaims;
+import com.numble.team3.jwt.TokenHelper;
+import com.numble.team3.sign.application.mapper.SignUpMapper;
+import com.numble.team3.sign.application.request.SignInDto;
+import com.numble.team3.sign.application.request.SignUpDto;
+import com.numble.team3.sign.application.response.TokenDto;
+import com.numble.team3.exception.sign.SignInFailureException;
+import com.numble.team3.sign.infra.RedisUtils;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RedisSignService implements SignService {
+
+  private final JpaAccountRepository accountRepository;
+  private final PasswordEncoder passwordEncoder;
+  private final TokenHelper accessTokenHelper;
+  private final TokenHelper refreshTokenHelper;
+  private final RedisUtils redisUtils;
+
+  @Transactional
+  @Override
+  public void signUp(SignUpDto dto) {
+    validateSignUpInfo(dto);
+
+    accountRepository.save(SignUpMapper.INSTANCE.toEntity(dto));
+  }
+
+  @Transactional(readOnly = true)
+  @Override
+  public TokenDto signIn(SignInDto dto) {
+    Account account = accountRepository.findByEmail(dto.getEmail())
+      .orElseThrow(AccountNotFoundException::new);
+
+    validatePassword(dto, account);
+
+    PrivateClaims privateClaims = createPrivateClaims(account);
+    String accessToken = accessTokenHelper.createToken(privateClaims);
+    String refreshToken = refreshTokenHelper.createToken(privateClaims);
+
+    redisUtils.saveAccessToken(account.getId(), accessToken);
+    redisUtils.saveRefreshToken(account.getId(), refreshToken);
+
+    return new TokenDto(accessToken, refreshToken);
+  }
+
+  @Override
+  public TokenDto createAccessTokenByRefreshToken(String refreshToken) {
+    PrivateClaims privateClaims = refreshTokenHelper.parse(refreshToken)
+      .orElseThrow(TokenFailureException::new);
+
+    if (!redisUtils.validToken(refreshToken, "refreshToken",
+      Optional.ofNullable(privateClaims.getAccountId()))) {
+      throw new TokenFailureException();
+    }
+
+    String accessToken = accessTokenHelper.createToken(privateClaims);
+    Long accountId = Long.valueOf(privateClaims.getAccountId());
+
+    redisUtils.deleteToken("accessToken", accountId);
+    redisUtils.saveAccessToken(accountId, accessToken);
+
+    return new TokenDto(accessToken, refreshToken);
+  }
+
+  @Override
+  public void logout(String accessToken) {
+    Long accountId = accessTokenHelper.parse(accessToken)
+      .map(claims -> Long.valueOf(claims.getAccountId()))
+      .orElseThrow(TokenFailureException::new);
+
+    redisUtils.deleteToken("refreshToken", accountId);
+    redisUtils.deleteToken("accessToken", accountId);
+  }
+
+  private void validateSignUpInfo(SignUpDto dto) {
+    if (accountRepository.existsByEmail(dto.getEmail())) {
+      throw new AccountEmailAlreadyExistsException();
+    }
+    if (accountRepository.existsByNickname(dto.getNickname())) {
+      throw new AccountNicknameAlreadyExistsException();
+    }
+  }
+
+  private void validatePassword(SignInDto dto, Account account) {
+    if (!passwordEncoder.matches(dto.getPassword(), account.getPassword())) {
+      throw new SignInFailureException();
+    }
+  }
+
+  private PrivateClaims createPrivateClaims(Account account) {
+
+    return new PrivateClaims(String.valueOf(account.getId()),
+      List.of(account.getRoleType().toString()));
+  }
+}

--- a/src/main/java/com/numble/team3/sign/application/SignService.java
+++ b/src/main/java/com/numble/team3/sign/application/SignService.java
@@ -1,0 +1,16 @@
+package com.numble.team3.sign.application;
+
+import com.numble.team3.sign.application.request.SignInDto;
+import com.numble.team3.sign.application.request.SignUpDto;
+import com.numble.team3.sign.application.response.TokenDto;
+
+public interface SignService {
+
+  void signUp(SignUpDto dto);
+
+  TokenDto signIn(SignInDto dto);
+
+  TokenDto createAccessTokenByRefreshToken(String refreshToken);
+
+  void logout(String accessToken);
+}

--- a/src/main/java/com/numble/team3/sign/application/advice/SignRestControllerAdvice.java
+++ b/src/main/java/com/numble/team3/sign/application/advice/SignRestControllerAdvice.java
@@ -1,0 +1,40 @@
+package com.numble.team3.sign.application.advice;
+
+import com.numble.team3.exception.sign.SignInFailureException;
+import com.numble.team3.exception.sign.TokenFailureException;
+import com.numble.team3.sign.controller.SignController;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(assignableTypes = {SignController.class})
+public class SignRestControllerAdvice {
+
+  @ExceptionHandler(BindException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  Map<String, String> bindException(BindException e) {
+    return createResponse(e.getBindingResult().getFieldError().getDefaultMessage());
+  }
+
+  @ExceptionHandler(TokenFailureException.class)
+  @ResponseStatus(HttpStatus.UNAUTHORIZED)
+  Map<String, String> tokenFailureExceptionHandler() {
+    return createResponse("유효하지 않은 토큰입니다.");
+  }
+
+  @ExceptionHandler(SignInFailureException.class)
+  @ResponseStatus(HttpStatus.UNAUTHORIZED)
+  Map<String, String> signInFailureException() {
+    return createResponse("로그인에 실패했습니다.");
+  }
+
+  private Map<String, String> createResponse(String message) {
+    Map<String, String> response = new HashMap<>();
+    response.put("message", message);
+    return response;
+  }
+}

--- a/src/main/java/com/numble/team3/sign/application/mapper/SignUpMapper.java
+++ b/src/main/java/com/numble/team3/sign/application/mapper/SignUpMapper.java
@@ -1,0 +1,17 @@
+package com.numble.team3.sign.application.mapper;
+
+import com.numble.team3.account.domain.Account;
+import com.numble.team3.sign.application.request.SignUpDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface SignUpMapper {
+
+  SignUpMapper INSTANCE = Mappers.getMapper(SignUpMapper.class);
+
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "password", expression = "java(org.springframework.security.crypto.factory.PasswordEncoderFactories.createDelegatingPasswordEncoder().encode(dto.getPassword()))")
+  Account toEntity(SignUpDto dto);
+}

--- a/src/main/java/com/numble/team3/sign/application/request/SignInDto.java
+++ b/src/main/java/com/numble/team3/sign/application/request/SignInDto.java
@@ -1,0 +1,19 @@
+package com.numble.team3.sign.application.request;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SignInDto {
+
+  @NotBlank(message = "이메일을 입력해주세요.")
+  @Email(message = "이메일 형식으로 입력해주세요.")
+  private String email;
+
+  @NotBlank(message = "비밀번호를 입력해주세요.")
+  private String password;
+}

--- a/src/main/java/com/numble/team3/sign/application/request/SignUpDto.java
+++ b/src/main/java/com/numble/team3/sign/application/request/SignUpDto.java
@@ -1,0 +1,22 @@
+package com.numble.team3.sign.application.request;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SignUpDto {
+
+  @NotBlank(message = "이메일을 입력해주세요.")
+  @Email(message = "이메일 형식으로 입력해주세요.")
+  private String email;
+
+  @NotBlank(message = "비밀번호를 입력해주세요.")
+  private String password;
+
+  @NotBlank(message = "닉네임을 입력해주세요.")
+  private String nickname;
+}

--- a/src/main/java/com/numble/team3/sign/controller/SignController.java
+++ b/src/main/java/com/numble/team3/sign/controller/SignController.java
@@ -1,0 +1,95 @@
+package com.numble.team3.sign.controller;
+
+import com.numble.team3.sign.application.SignService;
+import com.numble.team3.sign.application.request.SignInDto;
+import com.numble.team3.sign.application.request.SignUpDto;
+import com.numble.team3.sign.application.response.TokenDto;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class SignController {
+
+  private final SignService signService;
+
+  @PostMapping(value = "/sign-up", produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity signUp(@Valid @RequestBody SignUpDto dto) {
+    signService.signUp(dto);
+
+    return new ResponseEntity(HttpStatus.CREATED);
+  }
+
+  @PostMapping(value = "/sign-in")
+  public ResponseEntity<TokenDto> signIn(@Valid @RequestBody SignInDto dto,
+    HttpServletResponse response) {
+      TokenDto token = signService.signIn(dto);
+      createCookie("accessToken", token.getAccessToken(), 1800, response);
+      createCookie("refreshToken", token.getRefreshToken(), 604800, response);
+
+      return new ResponseEntity<>(token, HttpStatus.OK);
+  }
+
+  @GetMapping("/logout")
+  public ResponseEntity logout(HttpServletRequest request, HttpServletResponse response) {
+    for (Cookie cookie : request.getCookies()) {
+      if (cookie.getName().equals("accessToken")) {
+        signService.logout(cookie.getValue());
+      }
+    }
+
+    deleteCookie("accessToken", response);
+    deleteCookie("refreshToken", response);
+
+    return new ResponseEntity(HttpStatus.OK);
+  }
+
+  @GetMapping("/refresh-token")
+  public ResponseEntity createAccessTokenByRefreshToken(HttpServletRequest request,
+    HttpServletResponse response) {
+    for (Cookie cookie : request.getCookies()) {
+      if (cookie.getName().equals("refreshToken")) {
+        TokenDto token = signService.createAccessTokenByRefreshToken(
+          URLDecoder.decode(cookie.getValue(), StandardCharsets.UTF_8));
+
+        createCookie("accessToken", token.getAccessToken(), 1800, response);
+
+        return new ResponseEntity(HttpStatus.OK);
+      }
+    }
+    return new ResponseEntity(HttpStatus.UNAUTHORIZED);
+  }
+
+  private void createCookie(String key, String token, int maxAge, HttpServletResponse response) {
+    Cookie cookie = new Cookie(key, URLEncoder.encode(token, StandardCharsets.UTF_8));
+    cookie.setSecure(true);
+    cookie.setHttpOnly(true);
+    cookie.setMaxAge(maxAge);
+    cookie.setPath("/");
+
+    response.addCookie(cookie);
+  }
+
+  private void deleteCookie(String key, HttpServletResponse response) {
+    Cookie cookie = new Cookie(key, null);
+    cookie.setMaxAge(0);
+    cookie.setPath("/");
+
+    response.addCookie(cookie);
+  }
+}

--- a/src/main/java/com/numble/team3/sign/infra/RedisUtils.java
+++ b/src/main/java/com/numble/team3/sign/infra/RedisUtils.java
@@ -18,23 +18,17 @@ public class RedisUtils {
   private static final String SEPARATOR = "::";
 
   public void saveAccessToken(Long id, String accessToken) {
-    redisTemplate.opsForValue()
-      .set("accessToken" + SEPARATOR + id, accessToken,
-        accessTokenHelper.getExpiration(accessToken),
-        TimeUnit.SECONDS);
+    redisTemplate.opsForValue().set("accessToken" + SEPARATOR + id, accessToken,
+      accessTokenHelper.getExpiration(accessToken), TimeUnit.MILLISECONDS);
   }
 
   public void saveRefreshToken(Long id, String refreshToken) {
-    redisTemplate.opsForValue()
-      .set("refreshToken" + SEPARATOR + id, refreshToken,
-        refreshTokenHelper.getExpiration(refreshToken),
-        TimeUnit.SECONDS);
+    redisTemplate.opsForValue().set("refreshToken" + SEPARATOR + id, refreshToken,
+      refreshTokenHelper.getExpiration(refreshToken), TimeUnit.MILLISECONDS);
   }
 
   public boolean validToken(String token, String key, Optional<String> id) {
-    return token.equals(
-      getToken(key, id.map(accountId -> Long.valueOf(accountId)).orElse(
-        null)));
+    return token.equals(getToken(key, id.map(accountId -> Long.valueOf(accountId)).orElse(null)));
   }
 
   public String getToken(String key, Long id) {


### PR DESCRIPTION
## 개요
- #13 

## 작업사항
- 회원가입 & 로그인 & 로그아웃 기능을 추가했습니다.
    - 패키지 `sign`에 전체적으로 코드를 작성했습니다.
        - `mapstruct` 사용을 위해 `Account` 엔티티에 빌더 패턴을 추가했습니다.
        - 회원가입 시 중복 체크를 위해 `JpaAccountRepository`에 메소드를 추가했습니다.
    - 커스텀 예외는 `exception` 패키지의 도메인 명 패키지 안에 정의했습니다.