### PR TITLE
#17 회원가입 시 비밀번호를 넣지 않는 문제 추가 수정

### DIFF
--- a/src/main/java/com/numble/team3/account/domain/Account.java
+++ b/src/main/java/com/numble/team3/account/domain/Account.java
@@ -1,5 +1,6 @@
 package com.numble.team3.account.domain;
 
+import com.numble.team3.sign.application.request.SignUpDto;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -14,6 +15,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Entity
 @Getter
@@ -43,16 +45,31 @@ public class Account {
   @Column(columnDefinition = "tinyint(1)")
   private boolean deleted;
 
-  public Account(String email, String nickname, String profile) {
+  public static Account createSignUpOauth2Account(String email, String nickname, String profile) {
+    Account account = new Account();
+    account.initSignUpOauth2AccountField(email, nickname, profile);
+    return account;
+  }
+
+  public static Account createSignUpAccount(String email, String nickname, String password) {
+    Account account = new Account();
+    account.initSignUpAccountField(email, nickname, password);
+    return account;
+  }
+
+  private void initSignUpOauth2AccountField(String email, String nickname, String profile) {
     this.email = email;
     this.nickname = nickname;
     this.profile = profile;
   }
 
-  public Account(String email, String nickname, String password, RoleType roleType) {
+  private void initSignUpAccountField(String email, String nickname, String password) {
     this.email = email;
     this.nickname = nickname;
     this.password = password;
-    this.roleType = roleType;
+  }
+
+  public void changeDeleted(boolean deleted) {
+    this.deleted = deleted;
   }
 }

--- a/src/main/java/com/numble/team3/security/OAuth2SuccessHandler.java
+++ b/src/main/java/com/numble/team3/security/OAuth2SuccessHandler.java
@@ -43,8 +43,8 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
   private Account convertAccount(OAuth2User oAuth2User) {
     Map<String, Object> attributes = oAuth2User.getAttributes();
 
-    return new Account((String) attributes.get("email"), (String) attributes.get("nickname"),
-      (String) attributes.get("profile"));
+    return Account.createSignUpOauth2Account(
+      (String) attributes.get("email"), (String) attributes.get("nickname"), (String) attributes.get("profile"));
   }
 
   private void accountProcess(Account account, HttpServletResponse response) {

--- a/src/main/java/com/numble/team3/sign/application/RedisSignService.java
+++ b/src/main/java/com/numble/team3/sign/application/RedisSignService.java
@@ -35,13 +35,8 @@ public class RedisSignService implements SignService {
   @Override
   public void signUp(SignUpDto dto) {
     validateSignUpInfo(dto);
-    Account account =
-        new Account(
-            dto.getEmail(),
-            dto.getNickname(),
-            passwordEncoder.encode(dto.getPassword()),
-            RoleType.ROLE_USER);
-    accountRepository.save(account);
+
+    accountRepository.save(SignUpDto.toEntity(dto, passwordEncoder));
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/com/numble/team3/sign/application/request/SignUpDto.java
+++ b/src/main/java/com/numble/team3/sign/application/request/SignUpDto.java
@@ -1,10 +1,12 @@
 package com.numble.team3.sign.application.request;
 
+import com.numble.team3.account.domain.Account;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -19,4 +21,9 @@ public class SignUpDto {
 
   @NotBlank(message = "닉네임을 입력해주세요.")
   private String nickname;
+
+  public static Account toEntity(SignUpDto dto, PasswordEncoder passwordEncoder) {
+    return Account.createSignUpAccount(
+      dto.getEmail(), dto.getNickname(), passwordEncoder.encode(dto.getPassword()));
+  }
 }


### PR DESCRIPTION
## 개요
- #17
- 추가 수정

## 작업사항
- 현재 `Account`의 경우 기본값으로 `RoleType`을 `RoleType.ROLE_USER`로 가지고 있으므로 기본값을 세팅해 줄 필요가 없습니다.
- 소셜 회원가입 처리 시 `Account`는 `email`, `nickname`, `profile`을 초기화 해야 합니다.
- 일반 회원가입 처리 시 `Account`는 `email`, `nickname`, `password`를 초기화 해야 합니다.
    - 두 가지 모두 `String` 타입의 매개변수가 세 개이기 때문에 생성자로 처리할 수 없어 `Account`에 정적 팩토리 메소드를 사용했습니다.
    - 기존에는 `MapStruct`을 사용했기 때문에 고려할 필요가 없었지만, 제외하면서 발생한 오류였습니다. 
- `SignService.signUp` 메소드에서 직접 `Account` 엔티티를 생성하는 것을 `dto`를 통해 생성하도록 변경했습니다.
    - `SignUpDto`에 `toEntity` 메소드를 추가했습니다.