### PR TITLE
[refactor] #21 access token 헤더로 관리 방식 수정

### DIFF
--- a/src/main/java/com/numble/team3/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/numble/team3/security/JwtAuthenticationFilter.java
@@ -40,9 +40,6 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
   }
 
   private Optional<String> extractToken(ServletRequest request) {
-    return Arrays.stream(
-        Optional.ofNullable(((HttpServletRequest) request).getCookies()).orElse(new Cookie[]{}))
-      .filter(cookie -> cookie.getName().equals("accessToken"))
-      .map(cookie -> URLDecoder.decode(cookie.getValue(), StandardCharsets.UTF_8)).findFirst();
+    return Optional.ofNullable(((HttpServletRequest)request).getHeader("Authorization"));
   }
 }

--- a/src/main/java/com/numble/team3/sign/application/RedisSignService.java
+++ b/src/main/java/com/numble/team3/sign/application/RedisSignService.java
@@ -1,10 +1,8 @@
 package com.numble.team3.sign.application;
 
 import com.numble.team3.account.domain.Account;
-import com.numble.team3.account.domain.RoleType;
 import com.numble.team3.exception.account.AccountEmailAlreadyExistsException;
 import com.numble.team3.exception.account.AccountNicknameAlreadyExistsException;
-import com.numble.team3.exception.account.AccountNotFoundException;
 import com.numble.team3.account.infra.JpaAccountRepository;
 import com.numble.team3.exception.sign.TokenFailureException;
 import com.numble.team3.jwt.PrivateClaims;
@@ -43,7 +41,7 @@ public class RedisSignService implements SignService {
   @Override
   public TokenDto signIn(SignInDto dto) {
     Account account =
-        accountRepository.findByEmail(dto.getEmail()).orElseThrow(AccountNotFoundException::new);
+      accountRepository.findByEmail(dto.getEmail()).orElseThrow(SignInFailureException::new);
 
     validatePassword(dto, account);
 

--- a/src/main/java/com/numble/team3/sign/controller/SignController.java
+++ b/src/main/java/com/numble/team3/sign/controller/SignController.java
@@ -7,17 +7,19 @@ import com.numble.team3.sign.application.response.TokenDto;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -28,55 +30,46 @@ public class SignController {
 
   private final SignService signService;
 
-  @PostMapping(value = "/sign-up", produces = MediaType.APPLICATION_JSON_VALUE)
+  @PostMapping("/sign-up")
   public ResponseEntity signUp(@Valid @RequestBody SignUpDto dto) {
     signService.signUp(dto);
 
     return new ResponseEntity(HttpStatus.CREATED);
   }
 
-  @PostMapping(value = "/sign-in")
+  @PostMapping("/sign-in")
   public ResponseEntity<TokenDto> signIn(@Valid @RequestBody SignInDto dto,
     HttpServletResponse response) {
-      TokenDto token = signService.signIn(dto);
-      createCookie("accessToken", token.getAccessToken(), 1800, response);
-      createCookie("refreshToken", token.getRefreshToken(), 604800, response);
+    TokenDto token = signService.signIn(dto);
+    createCookie(token.getRefreshToken(), 604800, response);
 
-      return new ResponseEntity<>(token, HttpStatus.OK);
+    return new ResponseEntity<>(token, HttpStatus.OK);
   }
 
   @GetMapping("/logout")
-  public ResponseEntity logout(HttpServletRequest request, HttpServletResponse response) {
-    for (Cookie cookie : request.getCookies()) {
-      if (cookie.getName().equals("accessToken")) {
-        signService.logout(cookie.getValue());
-      }
-    }
-
-    deleteCookie("accessToken", response);
-    deleteCookie("refreshToken", response);
+  public ResponseEntity logout(@RequestHeader(value = "Authorization") String accessToken,
+    HttpServletResponse response) {
+    signService.logout(accessToken);
+    deleteCookie(response);
 
     return new ResponseEntity(HttpStatus.OK);
   }
 
   @GetMapping("/refresh-token")
-  public ResponseEntity createAccessTokenByRefreshToken(HttpServletRequest request,
-    HttpServletResponse response) {
+  public ResponseEntity createAccessTokenByRefreshToken(HttpServletRequest request) {
     for (Cookie cookie : request.getCookies()) {
       if (cookie.getName().equals("refreshToken")) {
-        TokenDto token = signService.createAccessTokenByRefreshToken(
-          URLDecoder.decode(cookie.getValue(), StandardCharsets.UTF_8));
-
-        createCookie("accessToken", token.getAccessToken(), 1800, response);
-
-        return new ResponseEntity(HttpStatus.OK);
+        return new ResponseEntity(signService.createAccessTokenByRefreshToken(
+          URLDecoder.decode(cookie.getValue(), StandardCharsets.UTF_8)), HttpStatus.OK);
       }
     }
-    return new ResponseEntity(HttpStatus.UNAUTHORIZED);
+    Map<String, String> message = new HashMap<>();
+    message.put("message", "refreshToken 쿠키가 누락되었습니다.");
+    return new ResponseEntity(message, HttpStatus.UNAUTHORIZED);
   }
 
-  private void createCookie(String key, String token, int maxAge, HttpServletResponse response) {
-    Cookie cookie = new Cookie(key, URLEncoder.encode(token, StandardCharsets.UTF_8));
+  private void createCookie(String token, int maxAge, HttpServletResponse response) {
+    Cookie cookie = new Cookie("refreshToken", URLEncoder.encode(token, StandardCharsets.UTF_8));
     cookie.setSecure(true);
     cookie.setHttpOnly(true);
     cookie.setMaxAge(maxAge);
@@ -85,8 +78,8 @@ public class SignController {
     response.addCookie(cookie);
   }
 
-  private void deleteCookie(String key, HttpServletResponse response) {
-    Cookie cookie = new Cookie(key, null);
+  private void deleteCookie(HttpServletResponse response) {
+    Cookie cookie = new Cookie("refreshToken", null);
     cookie.setMaxAge(0);
     cookie.setPath("/");
 


### PR DESCRIPTION
## 개요
- #21 

## 작업 사항
- `JwtAuthenticationFilter`에서 `Authrization` 헤더에서 `access token`을 추출하도록 수정
- `SignController`
    - 쿠키는 `refreshToken`만 생성하도록 수정
    - `logout` 시 `Authrization` 헤더에서 `access token`을 추출하도록 수정